### PR TITLE
don't rely on `onConnect` being a thing

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,8 @@ function (createConnection) {
           .on('connect', function () {
             backoffMethod.reset()
             emitter.connected = true
-            con.removeListener('connect', onConnect)
+            if(onConnect)
+              con.removeListener('connect', onConnect)
             emitter.emit('connect', con)
             //also support net style 'connection' method.
             emitter.emit('connection', con)


### PR DESCRIPTION
you might want to `reconnect().on('connection', ...)` instead and there is a matching `if(onConnect)` above for this.
