### PR TITLE
add emitter to options

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function (createConnection) {
     if(!onConnect)
       onConnect = opts.onConnect
 
-    var emitter = new EventEmitter()
+    var emitter = opts.emitter || new EventEmitter()
     emitter.connected = false
     emitter.reconnect = true
 


### PR DESCRIPTION
not always a new eventemitter is needed specially when a library using
this code is already creating event emitters on they own and want to add
reconnect functionality to them and their socket.

i could add a comment noting that this option should only be used when the person knows what she's doing.

refactored out of #2.
