### PR TITLE
fix redundant "disconnect" event on disconnect()

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,6 @@ function (createConnection) {
       if(emitter._connection)
         emitter._connection.end()
 
-      emitter.emit('disconnect')
       return emitter
     }
 

--- a/test/disconnect.js
+++ b/test/disconnect.js
@@ -24,8 +24,6 @@ test('disconnect', function (t) {
   var reconnector = reconnect({initialDelay: 10})
 
   reconnector.on('disconnect', function() {
-    if (!timeout) return
-
     clearTimeout(timeout)
     t.ok(true, 'disconnected')
   })


### PR DESCRIPTION
So when you call `.disconnect()` only one event is emitted.

There might be cases where emitting the event right away could be faster, but you call `.disconnect()` yourself anyways, so you know exactly when it's happening.

@dominictarr
