### PR TITLE
Emit fail event

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,9 @@ function (createConnection) {
     
     var backoffMethod = (backoff[opts.type] || backoff.fibonacci) (opts)
 
+    if(opts.failAfter)
+      backoffMethod.failAfter(opts.failAfter);
+
     backoffMethod.on('backoff', function (n, d, e) {
       emitter.emit('backoff', n, d, e)
     })


### PR DESCRIPTION
Allow to define a 'failAfter' option ([I've done a pull-request](https://github.com/MathieuTurcotte/node-backoff/pull/11) on `backoff` to add this feature) and dispatch a 'fail' event if that happens. This way, you can define a limit of unsuccessful tries instead of keep trying infinitely.
