### PR TITLE
Persistent contexts between reconnections

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,6 @@ function (createConnection) {
     if(!onConnect)
       onConnect = opts.onConnect
 
-    var ctx = {};
-
     var emitter = new EventEmitter()
     emitter.connected = false
     emitter.reconnect = true
@@ -31,7 +29,7 @@ function (createConnection) {
       if(!emitter.reconnect) return
 
       emitter.emit('reconnect', n, delay)
-      var con = ctx.prevCon = createConnection.apply(ctx, args)
+      var con = createConnection.apply(emitter, args)
       emitter._connection = con
 
       function onDisconnect (err) {


### PR DESCRIPTION
Allow to have a context object where to store some persistent data between reconnections. By default it's only storing the created connection, so the next time a reconnection is done, `createConnection` function can access to this persistent context on `this` and the previous connection on `this.prevCon`, so user can copy buffers between them or do other things in a transparent way.
