### PR TITLE
only react to connect once

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ function (createConnection) {
         })
       } else {
         con
-          .on('connect', function () {
+          .once('connect', function () {
             backoffMethod.reset()
             emitter.connected = true
             if(onConnect)


### PR DESCRIPTION
tighten behavior when reacting to connect events.
this will make reconnect work correctly in 0.11.14
see:
https://github.com/dominictarr/reconnect/issues/25
and:
https://github.com/joyent/node/issues/8499

I could have also fixed it in here, https://github.com/dominictarr/reconnect/blob/master/tls.js
but I felt that this change made the reconnect as a whole more robust, so was the better option.
