### PR TITLE
Emit 'connection' before 'connect'

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,10 +67,15 @@ function (createConnection) {
         .on('close', onDisconnect)
         .on('end'  , onDisconnect)
 
-      if(opts.immediate || con.constructor.name == 'Request') {
+      function emitConnect()
+      {
         emitter.connected = true
-        emitter.emit('connect', con)
         emitter.emit('connection', con)
+        emitter.emit('connect', con)
+      }
+
+      if(opts.immediate || con.constructor.name == 'Request') {
+        emitConnect()
         con.once('data', function () {
           //this is the only way to know for sure that data is coming...
           backoffMethod.reset()
@@ -79,12 +84,9 @@ function (createConnection) {
         con
           .once('connect', function () {
             backoffMethod.reset()
-            emitter.connected = true
             if(onConnect)
               con.removeListener('connect', onConnect)
-            emitter.emit('connect', con)
-            //also support net style 'connection' method.
-            emitter.emit('connection', con)
+            emitConnect()
           })
       }
     }


### PR DESCRIPTION
onConnect is attached to the 'connection' event, so it's possible that the user attach to the 'connect' event and get called previously to the connection was correctly done (if onConnect is used to finish the connection). Emitting the 'connection' event before the 'connect' one it ensures that onConnect is the first function being called and that the connection is correctly done.