### PR TITLE
Allow passing a backoff instance with a custom strategy

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,10 +19,10 @@ function (createConnection) {
 
     var backoffStrategy = opts.strategy || opts.type
     var backoffMethod
-    if (backoffStrategy instanceof backoff.Backoff)
-      backoffMethod = backoffStrategy
+    if (typeof backoffStrategy == 'string')
+      backoffMethod = backoff[backoffStrategy](opts)
     else
-      backoffMethod = (backoff[backoffStrategy] || backoff.fibonacci) (opts)
+      backoffMethod = backoffStrategy || backoff.fibonacci(opts)
 
     if(opts.failAfter)
       backoffMethod.failAfter(opts.failAfter);

--- a/index.js
+++ b/index.js
@@ -17,7 +17,12 @@ function (createConnection) {
       //use "connection" to match core (net) api.
       emitter.on('connection', onConnect)
 
-    var backoffMethod = (backoff[opts.type] || backoff.fibonacci) (opts)
+    var backoffStrategy = opts.strategy || opts.type
+    var backoffMethod
+    if (backoffStrategy instanceof backoff.Backoff)
+      backoffMethod = backoffStrategy
+    else
+      backoffMethod = (backoff[backoffStrategy] || backoff.fibonacci) (opts)
 
     if(opts.failAfter)
       backoffMethod.failAfter(opts.failAfter);


### PR DESCRIPTION
As discussed in #32, this changeset allows a backoff instance to be passed to reconnect-core.

the option key `type` didn't feel right any more, so I made it so you could use `strategy` or `type`, let me know if you don't agree.

So you should be able to do something like this:
```javascript
var backoff = require('backoff')

myStrategy = {
  next: function() { return 10000; },
  reset: function() { }
}
var re = reconnect({
  strategy: new backoff.Backoff(myStrategy),
  failAfter: Infinity,
  randomisationFactor: 0,
  immediate: false
}, function (stream) {
  // stream = the stream you should consume 
})
```